### PR TITLE
Fixed name of generated comments file

### DIFF
--- a/src/API/CompanyName.MyMeetings.API/SwaggerExtensions.cs
+++ b/src/API/CompanyName.MyMeetings.API/SwaggerExtensions.cs
@@ -22,7 +22,7 @@ namespace CompanyName.MyMeetings.API
                 });
 
                 var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                var commentsFileName = Assembly.GetExecutingAssembly().GetName().Name + ".XML";
+                var commentsFileName = Assembly.GetExecutingAssembly().GetName().Name + ".xml";
                 var commentsFile = Path.Combine(baseDirectory, commentsFileName);
                 options.IncludeXmlComments(commentsFile);
 


### PR DESCRIPTION
File is generated for Swagger documentation purposes. File has .xml
extension written in lowercase. In source code extension of the file
was written in uppercase and UNIX system did not recognized the file.