### PR TITLE
Remove Notification properties that are also present in DomainEvent

### DIFF
--- a/src/Modules/Meetings/Application/MeetingGroupProposals/MeetingGroupProposedNotification.cs
+++ b/src/Modules/Meetings/Application/MeetingGroupProposals/MeetingGroupProposedNotification.cs
@@ -1,17 +1,15 @@
 ﻿using System;
 using CompanyName.MyMeetings.BuildingBlocks.Application.Events;
-using CompanyName.MyMeetings.Modules.Meetings.Domain.MeetingGroupProposals;
 using CompanyName.MyMeetings.Modules.Meetings.Domain.MeetingGroupProposals.Events;
+using Newtonsoft.Json;
 
 namespace CompanyName.MyMeetings.Modules.Meetings.Application.MeetingGroupProposals
 {
     public class MeetingGroupProposedNotification : DomainNotificationBase<MeetingGroupProposedDomainEvent>
     {
-        public MeetingGroupProposalId MeetingGroupProposalId { get; }
-
+        [JsonConstructor]
         public MeetingGroupProposedNotification(MeetingGroupProposedDomainEvent domainEvent, Guid id) : base(domainEvent, id)
         {
-            this.MeetingGroupProposalId = domainEvent.Id;
         }
     }
 }

--- a/src/Modules/Meetings/Application/MeetingGroups/MeetingGroupCreatedNotification.cs
+++ b/src/Modules/Meetings/Application/MeetingGroups/MeetingGroupCreatedNotification.cs
@@ -2,28 +2,15 @@
 using CompanyName.MyMeetings.BuildingBlocks.Application.Events;
 using CompanyName.MyMeetings.Modules.Meetings.Domain.MeetingGroups;
 using CompanyName.MyMeetings.Modules.Meetings.Domain.MeetingGroups.Events;
-using CompanyName.MyMeetings.Modules.Meetings.Domain.Members;
 using Newtonsoft.Json;
 
 namespace CompanyName.MyMeetings.Modules.Meetings.Application.MeetingGroups
 {
     internal class MeetingGroupCreatedNotification : DomainNotificationBase<MeetingGroupCreatedDomainEvent>
     {
-        internal MeetingGroupId MeetingGroupId { get; }
-
-        internal MemberId CreatorId { get; }
-
+        [JsonConstructor]
         internal MeetingGroupCreatedNotification(MeetingGroupCreatedDomainEvent domainEvent, Guid id) : base(domainEvent, id)
         {
-            this.MeetingGroupId = domainEvent.MeetingGroupId;
-            this.CreatorId = domainEvent.CreatorId;
-        }
-        
-        [JsonConstructor]
-        internal MeetingGroupCreatedNotification(MeetingGroupId meetingGroupId, MemberId creatorId, Guid id) : base(null, id)
-        {
-            this.MeetingGroupId = meetingGroupId;
-            this.CreatorId = creatorId;
         }
     }
 }

--- a/src/Modules/Meetings/Application/MeetingGroups/MeetingGroupCreatedSendEmailHandler.cs
+++ b/src/Modules/Meetings/Application/MeetingGroups/MeetingGroupCreatedSendEmailHandler.cs
@@ -21,8 +21,8 @@ namespace CompanyName.MyMeetings.Modules.Meetings.Application.MeetingGroups
             await _commandsScheduler.EnqueueAsync(
                 new SendMeetingGroupCreatedEmailCommand(
                     Guid.NewGuid(),
-                    notification.MeetingGroupId, 
-                    notification.CreatorId));
+                    notification.DomainEvent.MeetingGroupId, 
+                    notification.DomainEvent.CreatorId));
         }
     }
 }

--- a/src/Modules/Meetings/Application/Meetings/SendMeetingAttendeeAddedEmail/MeetingAttendeeAddedNotification.cs
+++ b/src/Modules/Meetings/Application/Meetings/SendMeetingAttendeeAddedEmail/MeetingAttendeeAddedNotification.cs
@@ -1,26 +1,15 @@
 ﻿using System;
 using CompanyName.MyMeetings.BuildingBlocks.Application.Events;
-using CompanyName.MyMeetings.Modules.Meetings.Domain.Meetings;
 using CompanyName.MyMeetings.Modules.Meetings.Domain.Meetings.Events;
-using CompanyName.MyMeetings.Modules.Meetings.Domain.Members;
 using Newtonsoft.Json;
 
 namespace CompanyName.MyMeetings.Modules.Meetings.Application.Meetings.SendMeetingAttendeeAddedEmail
 {
     public class MeetingAttendeeAddedNotification : DomainNotificationBase<MeetingAttendeeAddedDomainEvent>
     {
-        public MeetingId MeetingId { get; }
-
-        public MemberId AttendeeId { get; }
-
-        public MoneyValue Fee { get; }
-
         [JsonConstructor]
         public MeetingAttendeeAddedNotification(MeetingAttendeeAddedDomainEvent domainEvent, Guid id) : base(domainEvent, id)
         {
-            Fee = domainEvent.Fee;
-            this.MeetingId = domainEvent.MeetingId;
-            this.AttendeeId = domainEvent.AttendeeId;
         }
     }
 }

--- a/src/Modules/Meetings/Application/Meetings/SendMeetingAttendeeAddedEmail/MeetingAttendeeAddedNotificationHandler.cs
+++ b/src/Modules/Meetings/Application/Meetings/SendMeetingAttendeeAddedEmail/MeetingAttendeeAddedNotificationHandler.cs
@@ -20,8 +20,8 @@ namespace CompanyName.MyMeetings.Modules.Meetings.Application.Meetings.SendMeeti
             await _commandsScheduler.EnqueueAsync(
                 new SendMeetingAttendeeAddedEmailCommand(
                     Guid.NewGuid(),
-                    notification.AttendeeId, 
-                    notification.MeetingId));
+                    notification.DomainEvent.AttendeeId, 
+                    notification.DomainEvent.MeetingId));
         }
     }
 }

--- a/src/Modules/Payments/Application/MeetingGroupPaymentRegisters/RegisterPayment/PaymentRegisteredNotification.cs
+++ b/src/Modules/Payments/Application/MeetingGroupPaymentRegisters/RegisterPayment/PaymentRegisteredNotification.cs
@@ -1,20 +1,16 @@
 ﻿using System;
 using CompanyName.MyMeetings.BuildingBlocks.Application.Events;
-using CompanyName.MyMeetings.Modules.Payments.Domain.MeetingGroupPaymentRegisters;
 using CompanyName.MyMeetings.Modules.Payments.Domain.MeetingGroupPaymentRegisters.Events;
+using Newtonsoft.Json;
 
 namespace CompanyName.MyMeetings.Modules.Payments.Application.MeetingGroupPaymentRegisters.RegisterPayment
 {
     public class PaymentRegisteredNotification : DomainNotificationBase<PaymentRegisteredDomainEvent>
     {
+        [JsonConstructor]
         public PaymentRegisteredNotification(PaymentRegisteredDomainEvent domainEvent, Guid id) : base(domainEvent, id)
         {
-            MeetingGroupPaymentRegisterId = domainEvent.MeetingGroupPaymentRegisterId;
-            DateTo = domainEvent.DateTo;
         }
 
-        public MeetingGroupPaymentRegisterId MeetingGroupPaymentRegisterId { get; }
-
-        public DateTime DateTo { get; }
     }
 }

--- a/src/Modules/Payments/Application/MeetingGroupPaymentRegisters/RegisterPayment/PaymentRegisteredNotificationHandler.cs
+++ b/src/Modules/Payments/Application/MeetingGroupPaymentRegisters/RegisterPayment/PaymentRegisteredNotificationHandler.cs
@@ -20,8 +20,8 @@ namespace CompanyName.MyMeetings.Modules.Payments.Application.MeetingGroupPaymen
             _eventsBus.Publish(new PaymentRegisteredIntegrationEvent(
                 notification.Id,
                 notification.DomainEvent.OccurredOn,
-                notification.MeetingGroupPaymentRegisterId.Value,
-                notification.DateTo));
+                notification.DomainEvent.MeetingGroupPaymentRegisterId.Value,
+                notification.DomainEvent.DateTo));
 
             return Task.CompletedTask;
         }

--- a/src/Modules/Payments/Tests/IntegrationTests/MeetingGroupPayments/CreatePaymentRegisterTests.cs
+++ b/src/Modules/Payments/Tests/IntegrationTests/MeetingGroupPayments/CreatePaymentRegisterTests.cs
@@ -50,8 +50,8 @@ namespace CompanyName.MyMeetings.Modules.Payments.IntegrationTests.MeetingGroupP
 
             var paymentRegisteredNotification = await GetLastOutboxMessage<PaymentRegisteredNotification>();
 
-            Assert.That(paymentRegisteredNotification.DateTo, Is.EqualTo(endDate));
-            Assert.That(paymentRegisteredNotification.MeetingGroupPaymentRegisterId.Value, Is.EqualTo(registerId));
+            Assert.That(paymentRegisteredNotification.DomainEvent.DateTo, Is.EqualTo(endDate));
+            Assert.That(paymentRegisteredNotification.DomainEvent.MeetingGroupPaymentRegisterId.Value, Is.EqualTo(registerId));
         }
 
         [Test]


### PR DESCRIPTION
Closes #76 

* I also added the `[JsonConstructor]` Attribute so that all `Notification` follows the same pattern.
* I also removed a constructor from `MeetingGroupCreatedNotification.cs` which is not used anywhere.