### PR TITLE
Review comments for meeting

### DIFF
--- a/src/API/CompanyName.MyMeetings.API/Modules/Meetings/MeetingComments/MeetingCommentsController.cs
+++ b/src/API/CompanyName.MyMeetings.API/Modules/Meetings/MeetingComments/MeetingCommentsController.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using CompanyName.MyMeetings.API.Configuration.Authorization;
 using CompanyName.MyMeetings.Modules.Meetings.Application.Contracts;
 using CompanyName.MyMeetings.Modules.Meetings.Application.MeetingComments.AddCommentReply;
 using CompanyName.MyMeetings.Modules.Meetings.Application.MeetingComments.AddMeetingComment;
 using CompanyName.MyMeetings.Modules.Meetings.Application.MeetingComments.EditMeetingComment;
+using CompanyName.MyMeetings.Modules.Meetings.Application.MeetingComments.GetMeetingComments;
 using CompanyName.MyMeetings.Modules.Meetings.Application.MeetingComments.RemoveMeetingComment;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -20,6 +22,17 @@ namespace CompanyName.MyMeetings.API.Modules.Meetings.MeetingComments
         public MeetingCommentsController(IMeetingsModule meetingModule)
         {
             _meetingModule = meetingModule;
+        }
+
+        [HttpGet("{meetingId}")]
+        [HasPermission(MeetingsPermissions.GetMeetingComments)]
+        [ProducesResponseType(typeof(List<MeetingCommentDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetComments([FromRoute] Guid meetingId)
+        {
+            var comments =
+                await _meetingModule.ExecuteQueryAsync(new GetMeetingCommentsQuery(meetingId));
+
+            return Ok(comments);
         }
 
         [HttpPost]

--- a/src/API/CompanyName.MyMeetings.API/Modules/Meetings/MeetingComments/MeetingCommentsController.cs
+++ b/src/API/CompanyName.MyMeetings.API/Modules/Meetings/MeetingComments/MeetingCommentsController.cs
@@ -25,7 +25,6 @@ namespace CompanyName.MyMeetings.API.Modules.Meetings.MeetingComments
         }
 
         [HttpGet("{meetingId}")]
-        [HasPermission(MeetingsPermissions.GetMeetingComments)]
         [ProducesResponseType(typeof(List<MeetingCommentDto>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetComments([FromRoute] Guid meetingId)
         {

--- a/src/API/CompanyName.MyMeetings.API/Modules/Meetings/MeetingsPermissions.cs
+++ b/src/API/CompanyName.MyMeetings.API/Modules/Meetings/MeetingsPermissions.cs
@@ -19,7 +19,6 @@
         public const string EditMeetingGroupGeneralAttributes = "EditMeetingGroupGeneralAttributes";
         public const string JoinToGroup = "JoinToGroup";
         public const string LeaveMeetingGroup = "LeaveMeetingGroup";
-        public const string GetMeetingComments = "GetMeetingComments";
         public const string AddMeetingComment = "AddMeetingComment";
         public const string EditMeetingComment = "EditMeetingComment";
         public const string DeleteMeetingComment = "DeleteMeetingComment";

--- a/src/API/CompanyName.MyMeetings.API/Modules/Meetings/MeetingsPermissions.cs
+++ b/src/API/CompanyName.MyMeetings.API/Modules/Meetings/MeetingsPermissions.cs
@@ -19,6 +19,7 @@
         public const string EditMeetingGroupGeneralAttributes = "EditMeetingGroupGeneralAttributes";
         public const string JoinToGroup = "JoinToGroup";
         public const string LeaveMeetingGroup = "LeaveMeetingGroup";
+        public const string GetMeetingComments = "GetMeetingComments";
         public const string AddMeetingComment = "AddMeetingComment";
         public const string EditMeetingComment = "EditMeetingComment";
         public const string DeleteMeetingComment = "DeleteMeetingComment";

--- a/src/Database/CompanyName.MyMeetings.Database/Scripts/SeedDatabase.sql
+++ b/src/Database/CompanyName.MyMeetings.Database/Scripts/SeedDatabase.sql
@@ -99,9 +99,11 @@ INSERT INTO users.[Permissions] ([Code], [Name]) VALUES
 	('EditMeetingGroupGeneralAttributes','EditMeetingGroupGeneralAttributes'),
 	('JoinToGroup','JoinToGroup'),
 	('LeaveMeetingGroup','LeaveMeetingGroup'),
+    ('GetMeetingComments', 'GetMeetingComments'),
 	('AddMeetingComment','AddMeetingComment'),
 	('EditMeetingComment','EditMeetingComment'),
 	('DeleteMeetingComment','DeleteMeetingComment'),
+    ('AddMeetingCommentReply', 'AddMeetingCommentReply'),
 	('EnableMeetingCommenting','EnableMeetingCommenting'),
 	('DisableMeetingCommenting','DisableMeetingCommenting'),
 	('MyMeetingGroupsView','MyMeetingGroupsView'),
@@ -144,8 +146,10 @@ INSERT INTO users.RolesToPermissions VALUES ('Member', 'GetAllMeetingGroups')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'EditMeetingGroupGeneralAttributes')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'JoinToGroup')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'LeaveMeetingGroup')
+INSERT INTO users.RolesToPermissions VALUES ('Member', 'GetMeetingComments')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'AddMeetingComment')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'EditMeetingComment')
+INSERT INTO users.RolesToPermissions VALUES ('Member', 'AddMeetingCommentReply')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'GetAuthenticatedMemberMeetingGroups')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'GetMeetingGroupDetails')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'GetMeetingDetails')

--- a/src/Database/CompanyName.MyMeetings.Database/Scripts/SeedDatabase.sql
+++ b/src/Database/CompanyName.MyMeetings.Database/Scripts/SeedDatabase.sql
@@ -99,7 +99,6 @@ INSERT INTO users.[Permissions] ([Code], [Name]) VALUES
 	('EditMeetingGroupGeneralAttributes','EditMeetingGroupGeneralAttributes'),
 	('JoinToGroup','JoinToGroup'),
 	('LeaveMeetingGroup','LeaveMeetingGroup'),
-    ('GetMeetingComments', 'GetMeetingComments'),
 	('AddMeetingComment','AddMeetingComment'),
 	('EditMeetingComment','EditMeetingComment'),
 	('DeleteMeetingComment','DeleteMeetingComment'),
@@ -146,7 +145,6 @@ INSERT INTO users.RolesToPermissions VALUES ('Member', 'GetAllMeetingGroups')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'EditMeetingGroupGeneralAttributes')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'JoinToGroup')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'LeaveMeetingGroup')
-INSERT INTO users.RolesToPermissions VALUES ('Member', 'GetMeetingComments')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'AddMeetingComment')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'EditMeetingComment')
 INSERT INTO users.RolesToPermissions VALUES ('Member', 'AddMeetingCommentReply')


### PR DESCRIPTION
Hi @kgrzybek ! :) Long time no see :)

I created reviewing of the comments for the meeting. Two questions

1. Our story is defined: As an authorized User I can look through comments and replies - so all users should see comments for all meetings? Or it should be done as I implemented it - only members should be able to see the comments for the meeting?
2. Would we like to have a structured tree of comments or a simple list?

And of course, all other feedback is really welcome! :)