### PR TITLE
Documentation. Set max width for conceptual model diagramm

### DIFF
--- a/docs/PlantUML/Conceptual_Model.puml
+++ b/docs/PlantUML/Conceptual_Model.puml
@@ -1,4 +1,6 @@
 @startuml
+scale max 2000 width
+
 package "User Access" #f3e8f8 {
 object Permission
 object "User Role" as UserRole


### PR DESCRIPTION
I think may be online planuml server has some constraints and so cut the image this way:

![image](https://user-images.githubusercontent.com/19877050/112676552-a0821a00-8e79-11eb-8c3b-0307226c20a1.png)
