### PR TITLE
feat: missing JsonConstructorAttribute arch test for internal commands

### DIFF
--- a/src/Modules/Administration/Tests/ArchTests/Application/ApplicationTests.cs
+++ b/src/Modules/Administration/Tests/ArchTests/Application/ApplicationTests.cs
@@ -86,7 +86,11 @@ namespace CompanyName.MyMeetings.Modules.Administration.ArchTests.Application
         public void InternalCommand_Should_Have_JsonConstructorAttribute()
         {
             var types = Types.InAssembly(ApplicationAssembly)
-                .That().Inherit(typeof(InternalCommandBase<>)).GetTypes();
+                .That()
+                .Inherit(typeof(InternalCommandBase))
+                .Or()
+                .Inherit(typeof(InternalCommandBase<>))
+                .GetTypes();
 
             var failingTypes = new List<Type>();
 

--- a/src/Modules/Meetings/Tests/ArchTests/Application/ApplicationTests.cs
+++ b/src/Modules/Meetings/Tests/ArchTests/Application/ApplicationTests.cs
@@ -86,7 +86,11 @@ namespace CompanyName.MyMeetings.Modules.Meetings.ArchTests.Application
         public void InternalCommand_Should_Have_Constructor_With_JsonConstructorAttribute()
         {
             var types = Types.InAssembly(ApplicationAssembly)
-                .That().Inherit(typeof(InternalCommandBase)).GetTypes();
+                .That()
+                .Inherit(typeof(InternalCommandBase))
+                .Or()
+                .Inherit(typeof(InternalCommandBase<>))
+                .GetTypes();
 
             var failingTypes = new List<Type>();
 

--- a/src/Modules/Payments/Application/MeetingFees/MarkMeetingFeeAsPaid/MarkMeetingFeeAsPaidCommand.cs
+++ b/src/Modules/Payments/Application/MeetingFees/MarkMeetingFeeAsPaid/MarkMeetingFeeAsPaidCommand.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using CompanyName.MyMeetings.Modules.Payments.Application.Configuration.Commands;
 using MediatR;
+using Newtonsoft.Json;
 
 namespace CompanyName.MyMeetings.Modules.Payments.Application.MeetingFees.MarkMeetingFeeAsPaid
 {
     public class MarkMeetingFeeAsPaidCommand : InternalCommandBase<Unit>
     {
+        [JsonConstructor]
         public MarkMeetingFeeAsPaidCommand(Guid meetingFeeId)
         {
             MeetingFeeId = meetingFeeId;

--- a/src/Modules/Payments/Tests/ArchTests/Application/ApplicationTests.cs
+++ b/src/Modules/Payments/Tests/ArchTests/Application/ApplicationTests.cs
@@ -86,7 +86,11 @@ namespace CompanyName.MyMeetings.Modules.Payments.ArchTests.Application
         public void InternalCommand_Should_Have_JsonConstructorAttribute()
         {
             var types = Types.InAssembly(ApplicationAssembly)
-                .That().Inherit(typeof(InternalCommandBase)).GetTypes();
+                .That()
+                .Inherit(typeof(InternalCommandBase))
+                .Or()
+                .Inherit(typeof(InternalCommandBase<>))
+                .GetTypes();
 
             var failingTypes = new List<Type>();
 

--- a/src/Modules/UserAccess/Tests/ArchTests/Application/ApplicationTests.cs
+++ b/src/Modules/UserAccess/Tests/ArchTests/Application/ApplicationTests.cs
@@ -86,7 +86,11 @@ namespace CompanyName.MyMeetings.Modules.UserAccess.ArchTests.Application
         public void InternalCommand_Should_Have_JsonConstructorAttribute()
         {
             var types = Types.InAssembly(ApplicationAssembly)
-                .That().Inherit(typeof(InternalCommandBase)).GetTypes();
+                .That()
+                .Inherit(typeof(InternalCommandBase))
+                .Or()
+                .Inherit(typeof(InternalCommandBase<>))
+                .GetTypes();
 
             var failingTypes = new List<Type>();
 


### PR DESCRIPTION
Fix InternalCommand_Should_Have_JsonConstructorAttribute arch test for internal commands with and without result