### PR TITLE
feat: add arch tests for validators

### DIFF
--- a/src/Modules/Administration/Tests/ArchTests/Application/ApplicationTests.cs
+++ b/src/Modules/Administration/Tests/ArchTests/Application/ApplicationTests.cs
@@ -6,6 +6,7 @@ using CompanyName.MyMeetings.Modules.Administration.Application.Configuration.Co
 using CompanyName.MyMeetings.Modules.Administration.Application.Configuration.Queries;
 using CompanyName.MyMeetings.Modules.Administration.Application.Contracts;
 using CompanyName.MyMeetings.Modules.Administration.ArchTests.SeedWork;
+using FluentValidation;
 using MediatR;
 using NetArchTest.Rules;
 using Newtonsoft.Json;
@@ -77,6 +78,30 @@ namespace CompanyName.MyMeetings.Modules.Administration.ArchTests.Application
                     .ImplementInterface(typeof(ICommandHandler<>))
                         .Or()
                     .ImplementInterface(typeof(ICommandHandler<,>))
+                .Should().NotBePublic().GetResult().FailingTypes;
+
+            AssertFailingTypes(types);
+        }
+
+        [Test]
+        public void Validator_Should_Have_Name_EndingWith_Validator()
+        {
+            var result = Types.InAssembly(ApplicationAssembly)
+                .That()
+                .Inherit(typeof(AbstractValidator<>))
+                .Should()
+                .HaveNameEndingWith("Validator")
+                .GetResult();
+
+            AssertArchTestResult(result);
+        }
+
+        [Test]
+        public void Validators_Should_Not_Be_Public()
+        {
+            var types = Types.InAssembly(ApplicationAssembly)
+                .That()
+                .Inherit(typeof(AbstractValidator<>))
                 .Should().NotBePublic().GetResult().FailingTypes;
 
             AssertFailingTypes(types);

--- a/src/Modules/Meetings/Application/MeetingComments/EditMeetingComment/EditMeetingCommentCommandValidator.cs
+++ b/src/Modules/Meetings/Application/MeetingComments/EditMeetingComment/EditMeetingCommentCommandValidator.cs
@@ -2,7 +2,7 @@
 
 namespace CompanyName.MyMeetings.Modules.Meetings.Application.MeetingComments.EditMeetingComment
 {
-    public class EditMeetingCommentCommandValidator : AbstractValidator<EditMeetingCommentCommand>
+    internal class EditMeetingCommentCommandValidator : AbstractValidator<EditMeetingCommentCommand>
     {
         public EditMeetingCommentCommandValidator()
         {

--- a/src/Modules/Meetings/Application/MeetingGroupProposals/ProposeMeetingGroup/ProposeMeetingGroupCommandValidator.cs
+++ b/src/Modules/Meetings/Application/MeetingGroupProposals/ProposeMeetingGroup/ProposeMeetingGroupCommandValidator.cs
@@ -2,7 +2,7 @@
 
 namespace CompanyName.MyMeetings.Modules.Meetings.Application.MeetingGroupProposals.ProposeMeetingGroup
 {
-    public class ProposeMeetingGroupCommandValidator : AbstractValidator<ProposeMeetingGroupCommand>
+    internal class ProposeMeetingGroupCommandValidator : AbstractValidator<ProposeMeetingGroupCommand>
     {
         public ProposeMeetingGroupCommandValidator()
         {

--- a/src/Modules/Meetings/Tests/ArchTests/Application/ApplicationTests.cs
+++ b/src/Modules/Meetings/Tests/ArchTests/Application/ApplicationTests.cs
@@ -6,6 +6,7 @@ using CompanyName.MyMeetings.Modules.Meetings.Application.Configuration.Commands
 using CompanyName.MyMeetings.Modules.Meetings.Application.Configuration.Queries;
 using CompanyName.MyMeetings.Modules.Meetings.Application.Contracts;
 using CompanyName.MyMeetings.Modules.Meetings.ArchitectureTests.SeedWork;
+using FluentValidation;
 using MediatR;
 using NetArchTest.Rules;
 using Newtonsoft.Json;
@@ -77,6 +78,30 @@ namespace CompanyName.MyMeetings.Modules.Meetings.ArchTests.Application
                     .ImplementInterface(typeof(ICommandHandler<>))
                         .Or()
                     .ImplementInterface(typeof(ICommandHandler<,>))
+                .Should().NotBePublic().GetResult().FailingTypes;
+
+            AssertFailingTypes(types);
+        }
+
+        [Test]
+        public void Validator_Should_Have_Name_EndingWith_Validator()
+        {
+            var result = Types.InAssembly(ApplicationAssembly)
+                .That()
+                .Inherit(typeof(AbstractValidator<>))
+                .Should()
+                .HaveNameEndingWith("Validator")
+                .GetResult();
+
+            AssertArchTestResult(result);
+        }
+
+        [Test]
+        public void Validators_Should_Not_Be_Public()
+        {
+            var types = Types.InAssembly(ApplicationAssembly)
+                .That()
+                .Inherit(typeof(AbstractValidator<>))
                 .Should().NotBePublic().GetResult().FailingTypes;
 
             AssertFailingTypes(types);

--- a/src/Modules/Payments/Tests/ArchTests/Application/ApplicationTests.cs
+++ b/src/Modules/Payments/Tests/ArchTests/Application/ApplicationTests.cs
@@ -6,6 +6,7 @@ using CompanyName.MyMeetings.Modules.Payments.Application.Configuration.Commands
 using CompanyName.MyMeetings.Modules.Payments.Application.Configuration.Queries;
 using CompanyName.MyMeetings.Modules.Payments.Application.Contracts;
 using CompanyName.MyMeetings.Modules.Payments.ArchTests.SeedWork;
+using FluentValidation;
 using MediatR;
 using NetArchTest.Rules;
 using Newtonsoft.Json;
@@ -77,6 +78,30 @@ namespace CompanyName.MyMeetings.Modules.Payments.ArchTests.Application
                     .ImplementInterface(typeof(ICommandHandler<>))
                         .Or()
                     .ImplementInterface(typeof(ICommandHandler<,>))
+                .Should().NotBePublic().GetResult().FailingTypes;
+
+            AssertFailingTypes(types);
+        }
+
+        [Test]
+        public void Validator_Should_Have_Name_EndingWith_Validator()
+        {
+            var result = Types.InAssembly(ApplicationAssembly)
+                .That()
+                .Inherit(typeof(AbstractValidator<>))
+                .Should()
+                .HaveNameEndingWith("Validator")
+                .GetResult();
+
+            AssertArchTestResult(result);
+        }
+
+        [Test]
+        public void Validators_Should_Not_Be_Public()
+        {
+            var types = Types.InAssembly(ApplicationAssembly)
+                .That()
+                .Inherit(typeof(AbstractValidator<>))
                 .Should().NotBePublic().GetResult().FailingTypes;
 
             AssertFailingTypes(types);

--- a/src/Modules/UserAccess/Application/Authentication/Authenticate/AuthenticateCommandValidator.cs
+++ b/src/Modules/UserAccess/Application/Authentication/Authenticate/AuthenticateCommandValidator.cs
@@ -2,7 +2,7 @@
 
 namespace CompanyName.MyMeetings.Modules.UserAccess.Application.Authentication.Authenticate
 {
-    public class AuthenticateCommandValidator : AbstractValidator<AuthenticateCommand>
+    internal class AuthenticateCommandValidator : AbstractValidator<AuthenticateCommand>
     {
         public AuthenticateCommandValidator()
         {

--- a/src/Modules/UserAccess/Tests/ArchTests/Application/ApplicationTests.cs
+++ b/src/Modules/UserAccess/Tests/ArchTests/Application/ApplicationTests.cs
@@ -6,6 +6,7 @@ using CompanyName.MyMeetings.Modules.UserAccess.Application.Configuration.Comman
 using CompanyName.MyMeetings.Modules.UserAccess.Application.Configuration.Queries;
 using CompanyName.MyMeetings.Modules.UserAccess.Application.Contracts;
 using CompanyName.MyMeetings.Modules.UserAccess.ArchTests.SeedWork;
+using FluentValidation;
 using MediatR;
 using NetArchTest.Rules;
 using Newtonsoft.Json;
@@ -77,6 +78,30 @@ namespace CompanyName.MyMeetings.Modules.UserAccess.ArchTests.Application
                     .ImplementInterface(typeof(ICommandHandler<>))
                         .Or()
                     .ImplementInterface(typeof(ICommandHandler<,>))
+                .Should().NotBePublic().GetResult().FailingTypes;
+
+            AssertFailingTypes(types);
+        }
+
+        [Test]
+        public void Validator_Should_Have_Name_EndingWith_Validator()
+        {
+            var result = Types.InAssembly(ApplicationAssembly)
+                .That()
+                .Inherit(typeof(AbstractValidator<>))
+                .Should()
+                .HaveNameEndingWith("Validator")
+                .GetResult();
+
+            AssertArchTestResult(result);
+        }
+
+        [Test]
+        public void Validators_Should_Not_Be_Public()
+        {
+            var types = Types.InAssembly(ApplicationAssembly)
+                .That()
+                .Inherit(typeof(AbstractValidator<>))
                 .Should().NotBePublic().GetResult().FailingTypes;
 
             AssertFailingTypes(types);


### PR DESCRIPTION
Add architecture tests for validators that assert that:
* Validator name ends with "Validator"
* Validator is not public