### PR TITLE
refactor(BuildingBlocks): rename context in DomainEventsAccessor

### DIFF
--- a/src/BuildingBlocks/Infrastructure/DomainEventsDispatching/DomainEventsAccessor.cs
+++ b/src/BuildingBlocks/Infrastructure/DomainEventsDispatching/DomainEventsAccessor.cs
@@ -7,16 +7,16 @@ namespace CompanyName.MyMeetings.BuildingBlocks.Infrastructure.DomainEventsDispa
 {
     public class DomainEventsAccessor : IDomainEventsAccessor
     {
-        private readonly DbContext _meetingsContext;
+        private readonly DbContext _dbContext;
 
-        public DomainEventsAccessor(DbContext meetingsContext)
+        public DomainEventsAccessor(DbContext dbContext)
         {
-            _meetingsContext = meetingsContext;
+            _dbContext = dbContext;
         }
 
         public IReadOnlyCollection<IDomainEvent> GetAllDomainEvents()
         {
-            var domainEntities = this._meetingsContext.ChangeTracker
+            var domainEntities = this._dbContext.ChangeTracker
                 .Entries<Entity>()
                 .Where(x => x.Entity.DomainEvents != null && x.Entity.DomainEvents.Any()).ToList();
 
@@ -27,7 +27,7 @@ namespace CompanyName.MyMeetings.BuildingBlocks.Infrastructure.DomainEventsDispa
 
         public void ClearAllDomainEvents()
         {
-            var domainEntities = this._meetingsContext.ChangeTracker
+            var domainEntities = this._dbContext.ChangeTracker
                 .Entries<Entity>()
                 .Where(x => x.Entity.DomainEvents != null && x.Entity.DomainEvents.Any()).ToList();
 


### PR DESCRIPTION
As the usage of this DbContext is somewhat abstract, in my opnion, `_meetingContext` name is too specific, and it could be misleading.