### PR TITLE
Add Directory.Packages.props

### DIFF
--- a/src/API/CompanyName.MyMeetings.API/CompanyName.MyMeetings.API.csproj
+++ b/src/API/CompanyName.MyMeetings.API/CompanyName.MyMeetings.API.csproj
@@ -7,12 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\BuildingBlocks\Infrastructure\CompanyName.MyMeetings.BuildingBlocks.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Modules\Administration\Infrastructure\CompanyName.MyMeetings.Modules.Administration.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Modules\Meetings\Infrastructure\CompanyName.MyMeetings.Modules.Meetings.Infrastructure.csproj" />

--- a/src/API/CompanyName.MyMeetings.API/CompanyName.MyMeetings.API.csproj
+++ b/src/API/CompanyName.MyMeetings.API/CompanyName.MyMeetings.API.csproj
@@ -5,12 +5,4 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\BuildingBlocks\Infrastructure\CompanyName.MyMeetings.BuildingBlocks.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\Modules\Administration\Infrastructure\CompanyName.MyMeetings.Modules.Administration.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\Modules\Meetings\Infrastructure\CompanyName.MyMeetings.Modules.Meetings.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\Modules\Payments\Infrastructure\CompanyName.MyMeetings.Modules.Payments.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\Modules\UserAccess\Infrastructure\CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/BuildingBlocks/Application/CompanyName.MyMeetings.BuildingBlocks.Application.csproj
+++ b/src/BuildingBlocks/Application/CompanyName.MyMeetings.BuildingBlocks.Application.csproj
@@ -1,11 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-  	<PackageReference Include="Dapper" Version="2.1.24" />
-  	<PackageReference Include="FluentValidation" Version="11.8.1" />
-	<PackageReference Include="IdentityServer4" Version="4.1.2" />
-	<PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
-  	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  	<PackageReference Include="Quartz" Version="3.8.0" />
-  	<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/BuildingBlocks/Domain/CompanyName.MyMeetings.BuildingBlocks.Domain.csproj
+++ b/src/BuildingBlocks/Domain/CompanyName.MyMeetings.BuildingBlocks.Domain.csproj
@@ -1,5 +1,1 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="MediatR" Version="12.2.0" />
-  </ItemGroup>
-</Project>
+<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/BuildingBlocks/Infrastructure/CompanyName.MyMeetings.BuildingBlocks.Infrastructure.csproj
+++ b/src/BuildingBlocks/Infrastructure/CompanyName.MyMeetings.BuildingBlocks.Infrastructure.csproj
@@ -1,11 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="Autofac" Version="7.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="Polly" Version="8.2.0" />
-    <PackageReference Include="SqlStreamStore.MsSql" Version="1.1.3" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/BuildingBlocks/Tests/Application.UnitTests/CompanyName.MyMeetings.BuildingBlocks.Application.UnitTests.csproj
+++ b/src/BuildingBlocks/Tests/Application.UnitTests/CompanyName.MyMeetings.BuildingBlocks.Application.UnitTests.csproj
@@ -1,5 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\Application\CompanyName.MyMeetings.BuildingBlocks.Application.csproj" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/BuildingBlocks/Tests/Application.UnitTests/CompanyName.MyMeetings.BuildingBlocks.Application.UnitTests.csproj
+++ b/src/BuildingBlocks/Tests/Application.UnitTests/CompanyName.MyMeetings.BuildingBlocks.Application.UnitTests.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Application\CompanyName.MyMeetings.BuildingBlocks.Application.csproj" />
   </ItemGroup>
 </Project>

--- a/src/CompanyName.MyMeetings.sln
+++ b/src/CompanyName.MyMeetings.sln
@@ -115,6 +115,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solutio
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		..\README.md = ..\README.md
 		stylecop.json = stylecop.json

--- a/src/Database/DatabaseMigrator/DatabaseMigrator.csproj
+++ b/src/Database/DatabaseMigrator/DatabaseMigrator.csproj
@@ -2,9 +2,4 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="dbup-sqlserver" Version="5.0.37" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
-  </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,10 +24,6 @@
     <Optimize>True</Optimize>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
-  </ItemGroup>
-
   <PropertyGroup Label="ConfigFiles">
     <StyleCopFile Condition=" '$(StyleCopFile)' == '' ">$([MSBuild]::GetPathOfFileAbove('stylecop.json',
       $(MSBuildProjectDirectory)))</StyleCopFile>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -11,42 +11,45 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BBDomainPath>..\..\..\BuildingBlocks\Domain\CompanyName.MyMeetings.BuildingBlocks.Domain.csproj</BBDomainPath>
-    <BBDomainPath Condition="Exists('..\$(BBDomainPath)')">..\$(BBDomainPath)</BBDomainPath>
-    
-    <BBInfrastructurePath>..\..\BuildingBlocks\Infrastructure\CompanyName.MyMeetings.BuildingBlocks.Infrastructure.csproj</BBInfrastructurePath>
-    <BBInfrastructurePath Condition="Exists('..\$(BBInfrastructurePath)')">..\$(BBInfrastructurePath)</BBInfrastructurePath>
-    <BBInfrastructurePath Condition="Exists('..\..\$(BBInfrastructurePath)')">..\..\$(BBInfrastructurePath)</BBInfrastructurePath>
-    
-    <BBIntegrationTestsPath>..\..\BuildingBlocks\Tests\IntegrationTests\CompanyName.MyMeetings.BuildingBlocks.IntegrationTests.csproj</BBIntegrationTestsPath>
-    <BBIntegrationTestsPath Condition="Exists('..\..\$(BBIntegrationTestsPath)')">..\..\$(BBIntegrationTestsPath)</BBIntegrationTestsPath>
+    <BBDomainPath>$(MSBuildThisFileDirectory)\BuildingBlocks\Domain\*.csproj</BBDomainPath>
+    <BBApplicationPath>$(MSBuildThisFileDirectory)\BuildingBlocks\Application\*.csproj</BBApplicationPath>
+    <BBInfrastructurePath>$(MSBuildThisFileDirectory)\BuildingBlocks\Infrastructure\*.csproj</BBInfrastructurePath>
+    <BBIntegrationTestsPath>$(MSBuildThisFileDirectory)\BuildingBlocks\Tests\IntegrationTests\*.csproj</BBIntegrationTestsPath>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Domain')) and !$(MSBuildProjectName.Contains('BuildingBlocks'))">
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('API'))">
+	<ProjectReference Include="..\..\Modules\**\Infrastructure\*.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectFullPath.Contains('BuildingBlocks')) and $(MSBuildProjectName.EndsWith('Application'))">
+    <ProjectReference Include="$(BBDomainPath)" />
+  </ItemGroup>	
+  <ItemGroup Condition="$(MSBuildProjectFullPath.Contains('BuildingBlocks')) and ($(MSBuildProjectName.EndsWith('UnitTests')) or $(MSBuildProjectName.EndsWith('Infrastructure')))">
+    <ProjectReference Include="$(BBApplicationPath)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectFullPath.Contains('src$([System.IO.Path]::DirectorySeparatorChar)Tests'))">
+    <ProjectReference Include="..\..\API\**\*.csproj" />
+	<ProjectReference Include="$(BBIntegrationTestsPath)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectFullPath.Contains('Modules')) and $(MSBuildProjectName.EndsWith('Domain'))">
     <ProjectReference Include="$(BBDomainPath)" />
   </ItemGroup>
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Domain.UnitTests')) and !$(MSBuildProjectName.Contains('BuildingBlocks'))">
-    <ProjectReference Include="..\..\Domain\*.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Application'))">
-    <ProjectReference Include="..\Domain\*.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.IntegrationTests')) and !$(MSBuildProjectName.Contains('BuildingBlocks'))">
-    <ProjectReference Include="..\..\Infrastructure\*.csproj" />
-    <ProjectReference Include="$(BBIntegrationTestsPath)" />
-  </ItemGroup>
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.ArchTests'))">
-    <ProjectReference Include="..\..\Infrastructure\*.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.IntegrationEvents')) and !$(MSBuildProjectName.Contains('BuildingBlocks'))">
+  <ItemGroup Condition="$(MSBuildProjectFullPath.Contains('Modules')) and $(MSBuildProjectName.EndsWith('IntegrationEvents'))">
     <ProjectReference Include="$(BBInfrastructurePath)" />
   </ItemGroup>
-  
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Application')) and !$(MSBuildProjectName.Contains('BuildingBlocks'))">
+  <ItemGroup Condition="$(MSBuildProjectFullPath.Contains('Modules')) and $(MSBuildProjectName.EndsWith('Application'))">
+    <ProjectReference Include="..\Domain\*.csproj" />
     <ProjectReference Include="..\IntegrationEvents\*.csproj" />
-  </ItemGroup>  
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Infrastructure'))">
+	<ProjectReference Include="..\..\**\IntegrationEvents\*.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="$(MSBuildProjectFullPath.Contains('Modules')) and $(MSBuildProjectName.EndsWith('Infrastructure'))">
     <ProjectReference Include="..\Application\*.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectFullPath.Contains('Modules')) and $(MSBuildProjectName.EndsWith('Tests'))">
+    <ProjectReference Include="..\..\Infrastructure\*.csproj" />
+    <ProjectReference Include="$(BBIntegrationTestsPath)" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,46 @@
+﻿<Project>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.API'))">
+    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Migrator'))">
+    <PackageReference Include="dbup-sqlserver" Version="5.0.37" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('BuildingBlocks.Domain'))">
+    <PackageReference Include="MediatR" Version="12.2.0" />
+  </ItemGroup>
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('BuildingBlocks.Application'))">
+    <PackageReference Include="Dapper" Version="2.1.24" />
+    <PackageReference Include="FluentValidation" Version="11.8.1" />
+    <PackageReference Include="IdentityServer4" Version="4.1.2" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Quartz" Version="3.8.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('BuildingBlocks.Infrastructure'))">
+    <PackageReference Include="Autofac" Version="7.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="Polly" Version="8.2.0" />
+    <PackageReference Include="SqlStreamStore.MsSql" Version="1.1.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests')) or $(MSBuildProjectName.EndsWith('SUT'))">
+    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="nunit" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+</Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,12 +1,12 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.API'))">
-    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('API'))">
+    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" PrivateAssets="All" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Migrator'))">
     <PackageReference Include="dbup-sqlserver" Version="5.0.37" />
@@ -35,7 +35,7 @@
     <PackageReference Include="SqlStreamStore.MsSql" Version="1.1.3" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests')) or $(MSBuildProjectName.EndsWith('SUT'))">
+  <ItemGroup Condition="$(MSBuildProjectFullPath.Contains('Tests'))">
     <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="nunit" Version="4.0.1" />

--- a/src/Modules/Administration/Application/CompanyName.MyMeetings.Modules.Administration.Application.csproj
+++ b/src/Modules/Administration/Application/CompanyName.MyMeetings.Modules.Administration.Application.csproj
@@ -1,6 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\Meetings\IntegrationEvents\CompanyName.MyMeetings.Modules.Meetings.IntegrationEvents.csproj" />
-    <ProjectReference Include="..\..\UserAccess\IntegrationEvents\CompanyName.MyMeetings.Modules.UserAccess.IntegrationEvents.csproj" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/Administration/Tests/ArchTests/CompanyName.MyMeetings.Modules.Administration.ArchTests.csproj
+++ b/src/Modules/Administration/Tests/ArchTests/CompanyName.MyMeetings.Modules.Administration.ArchTests.csproj
@@ -1,10 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/Administration/Tests/IntegrationTests/CompanyName.MyMeetings.Modules.Administration.IntegrationTests.csproj
+++ b/src/Modules/Administration/Tests/IntegrationTests/CompanyName.MyMeetings.Modules.Administration.IntegrationTests.csproj
@@ -1,9 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/Administration/Tests/UnitTests/CompanyName.MyMeetings.Modules.Administration.Domain.UnitTests.csproj
+++ b/src/Modules/Administration/Tests/UnitTests/CompanyName.MyMeetings.Modules.Administration.Domain.UnitTests.csproj
@@ -1,9 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/Meetings/Application/CompanyName.MyMeetings.Modules.Meetings.Application.csproj
+++ b/src/Modules/Meetings/Application/CompanyName.MyMeetings.Modules.Meetings.Application.csproj
@@ -1,7 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\Administration\IntegrationEvents\CompanyName.MyMeetings.Modules.Administration.IntegrationEvents.csproj" />
-    <ProjectReference Include="..\..\Payments\IntegrationEvents\CompanyName.MyMeetings.Modules.Payments.IntegrationEvents.csproj"/>
-    <ProjectReference Include="..\..\UserAccess\IntegrationEvents\CompanyName.MyMeetings.Modules.UserAccess.IntegrationEvents.csproj" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/Meetings/Tests/ArchTests/CompanyName.MyMeetings.Modules.Meetings.ArchTests.csproj
+++ b/src/Modules/Meetings/Tests/ArchTests/CompanyName.MyMeetings.Modules.Meetings.ArchTests.csproj
@@ -1,10 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/Meetings/Tests/IntegrationTests/CompanyName.MyMeetings.Modules.Meetings.IntegrationTests.csproj
+++ b/src/Modules/Meetings/Tests/IntegrationTests/CompanyName.MyMeetings.Modules.Meetings.IntegrationTests.csproj
@@ -1,9 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/Meetings/Tests/UnitTests/CompanyName.MyMeetings.Modules.Meetings.Domain.UnitTests.csproj
+++ b/src/Modules/Meetings/Tests/UnitTests/CompanyName.MyMeetings.Modules.Meetings.Domain.UnitTests.csproj
@@ -1,9 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/Payments/Application/CompanyName.MyMeetings.Modules.Payments.Application.csproj
+++ b/src/Modules/Payments/Application/CompanyName.MyMeetings.Modules.Payments.Application.csproj
@@ -1,7 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\Administration\IntegrationEvents\CompanyName.MyMeetings.Modules.Administration.IntegrationEvents.csproj" />
-    <ProjectReference Include="..\..\Meetings\IntegrationEvents\CompanyName.MyMeetings.Modules.Meetings.IntegrationEvents.csproj" />
-    <ProjectReference Include="..\..\UserAccess\IntegrationEvents\CompanyName.MyMeetings.Modules.UserAccess.IntegrationEvents.csproj" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/Payments/Tests/ArchTests/CompanyName.MyMeetings.Modules.Payments.ArchTests.csproj
+++ b/src/Modules/Payments/Tests/ArchTests/CompanyName.MyMeetings.Modules.Payments.ArchTests.csproj
@@ -1,10 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/Payments/Tests/IntegrationTests/CompanyName.MyMeetings.Modules.Payments.IntegrationTests.csproj
+++ b/src/Modules/Payments/Tests/IntegrationTests/CompanyName.MyMeetings.Modules.Payments.IntegrationTests.csproj
@@ -1,9 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/Payments/Tests/UnitTests/CompanyName.MyMeetings.Modules.Payments.Domain.UnitTests.csproj
+++ b/src/Modules/Payments/Tests/UnitTests/CompanyName.MyMeetings.Modules.Payments.Domain.UnitTests.csproj
@@ -1,9 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/UserAccess/Application/CompanyName.MyMeetings.Modules.UserAccess.Application.csproj
+++ b/src/Modules/UserAccess/Application/CompanyName.MyMeetings.Modules.UserAccess.Application.csproj
@@ -1,5 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\Meetings\IntegrationEvents\CompanyName.MyMeetings.Modules.Meetings.IntegrationEvents.csproj" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/UserAccess/Tests/ArchTests/CompanyName.MyMeetings.Modules.UserAccess.ArchTests.csproj
+++ b/src/Modules/UserAccess/Tests/ArchTests/CompanyName.MyMeetings.Modules.UserAccess.ArchTests.csproj
@@ -1,10 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/UserAccess/Tests/IntegrationTests/CompanyNames.MyMeetings.Modules.UserAccess.IntegrationTests.csproj
+++ b/src/Modules/UserAccess/Tests/IntegrationTests/CompanyNames.MyMeetings.Modules.UserAccess.IntegrationTests.csproj
@@ -1,9 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Modules/UserAccess/Tests/UnitTests/CompanyName.MyMeetings.Modules.UserAccess.Domain.UnitTests.csproj
+++ b/src/Modules/UserAccess/Tests/UnitTests/CompanyName.MyMeetings.Modules.UserAccess.Domain.UnitTests.csproj
@@ -1,9 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Tests/ArchTests/CompanyName.MyMeetings.ArchTests.csproj
+++ b/src/Tests/ArchTests/CompanyName.MyMeetings.ArchTests.csproj
@@ -1,14 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\API\CompanyName.MyMeetings.API\CompanyName.MyMeetings.API.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Tests/ArchTests/CompanyName.MyMeetings.ArchTests.csproj
+++ b/src/Tests/ArchTests/CompanyName.MyMeetings.ArchTests.csproj
@@ -1,5 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\API\CompanyName.MyMeetings.API\CompanyName.MyMeetings.API.csproj" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Tests/IntegrationTests/CompanyName.MyMeetings.IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/CompanyName.MyMeetings.IntegrationTests.csproj
@@ -1,13 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\API\CompanyName.MyMeetings.API\CompanyName.MyMeetings.API.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Tests/IntegrationTests/CompanyName.MyMeetings.IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/CompanyName.MyMeetings.IntegrationTests.csproj
@@ -1,5 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\API\CompanyName.MyMeetings.API\CompanyName.MyMeetings.API.csproj" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Tests/SUT/CompanyName.MyMeetings.SUT.csproj
+++ b/src/Tests/SUT/CompanyName.MyMeetings.SUT.csproj
@@ -1,12 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\API\CompanyName.MyMeetings.API\CompanyName.MyMeetings.API.csproj" />
   </ItemGroup>

--- a/src/Tests/SUT/CompanyName.MyMeetings.SUT.csproj
+++ b/src/Tests/SUT/CompanyName.MyMeetings.SUT.csproj
@@ -1,5 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\API\CompanyName.MyMeetings.API\CompanyName.MyMeetings.API.csproj" />
-  </ItemGroup>
-</Project>
+﻿<Project Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
### Changes:
- Migrated NuGet packages to a central place in **Directory.Packages.props**. It supports UI updates in comparison to old MSBuild solutions. This solution doesn't use [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management) (CPM) flag, only MSBuild NuGet feature. We have a standardized layout of projects so it doesn't make sense to store versions in one place and references in projects. Credits to @AlmarAubel for suggestions.
- Removed ProjectReferences from all projects. Directory.Build.targets is more readable because now represents folder structures and particular sets of projects. Changes the best to read in split mode.

This PR closes MSBuild changes, there are no hardcoded values and it fully works based on patterns. For example, by adding a new module it will automatically set all necessary dependencies for the new module and also add it to API. IntegrationEvents works similarly, it will automatically add new project events to other modules' applications.

The only manual thing to do is to add a new module and include all the projects in the solution, but this can be fixed by creating a module template.
