### PR TITLE
Move IdentityServer to UserModule Infrastructure

### DIFF
--- a/src/API/CompanyName.MyMeetings.API/Startup.cs
+++ b/src/API/CompanyName.MyMeetings.API/Startup.cs
@@ -14,12 +14,12 @@ using CompanyName.MyMeetings.BuildingBlocks.Infrastructure.Emails;
 using CompanyName.MyMeetings.Modules.Administration.Infrastructure.Configuration;
 using CompanyName.MyMeetings.Modules.Meetings.Infrastructure.Configuration;
 using CompanyName.MyMeetings.Modules.Payments.Infrastructure.Configuration;
-using CompanyName.MyMeetings.Modules.UserAccess.Application.IdentityServer;
 using CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.Configuration;
+using CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.Configuration.Identity;
 using Hellang.Middleware.ProblemDetails;
-using IdentityServer4.AccessTokenValidation;
-using IdentityServer4.Validation;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Server.HttpSys;
 using Serilog;
 using Serilog.Formatting.Compact;
 using ILogger = Serilog.ILogger;
@@ -55,7 +55,7 @@ namespace CompanyName.MyMeetings.API
 
             services.AddSwaggerDocumentation();
 
-            ConfigureIdentityServer(services);
+            services.ConfigureIdentityService();
 
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddSingleton<IExecutionContextAccessor, ExecutionContextAccessor>();
@@ -71,7 +71,7 @@ namespace CompanyName.MyMeetings.API
                 options.AddPolicy(HasPermissionAttribute.HasPermissionPolicyName, policyBuilder =>
                 {
                     policyBuilder.Requirements.Add(new HasPermissionAuthorizationRequirement());
-                    policyBuilder.AddAuthenticationSchemes(IdentityServerAuthenticationDefaults.AuthenticationScheme);
+                    policyBuilder.AddAuthenticationSchemes("Bearer");
                 });
             });
 
@@ -100,7 +100,7 @@ namespace CompanyName.MyMeetings.API
 
             app.UseSwaggerDocumentation();
 
-            app.UseIdentityServer();
+            app.AddIdentityService();
 
             if (env.IsDevelopment())
             {
@@ -135,28 +135,6 @@ namespace CompanyName.MyMeetings.API
             _loggerForApi = _logger.ForContext("Module", "API");
 
             _loggerForApi.Information("Logger configured");
-        }
-
-        private void ConfigureIdentityServer(IServiceCollection services)
-        {
-            services.AddIdentityServer()
-                .AddInMemoryIdentityResources(IdentityServerConfig.GetIdentityResources())
-                .AddInMemoryApiScopes(IdentityServerConfig.GetApiScopes())
-                .AddInMemoryApiResources(IdentityServerConfig.GetApis())
-                .AddInMemoryClients(IdentityServerConfig.GetClients())
-                .AddInMemoryPersistedGrants()
-                .AddProfileService<ProfileService>()
-                .AddDeveloperSigningCredential();
-
-            services.AddTransient<IResourceOwnerPasswordValidator, ResourceOwnerPasswordValidator>();
-
-            services.AddAuthentication(IdentityServerAuthenticationDefaults.AuthenticationScheme)
-                .AddIdentityServerAuthentication(IdentityServerAuthenticationDefaults.AuthenticationScheme, x =>
-                {
-                    x.Authority = "http://localhost:5000";
-                    x.ApiName = "myMeetingsAPI";
-                    x.RequireHttpsMetadata = false;
-                });
         }
 
         private void InitializeModules(ILifetimeScope container)

--- a/src/Modules/UserAccess/Application/CompanyName.MyMeetings.Modules.UserAccess.Application.csproj
+++ b/src/Modules/UserAccess/Application/CompanyName.MyMeetings.Modules.UserAccess.Application.csproj
@@ -2,7 +2,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Meetings\IntegrationEvents\CompanyName.MyMeetings.Modules.Meetings.IntegrationEvents.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="4.1.2" />
-  </ItemGroup>
 </Project>

--- a/src/Modules/UserAccess/Application/Contracts/CustomClaimTypes.cs
+++ b/src/Modules/UserAccess/Application/Contracts/CustomClaimTypes.cs
@@ -1,9 +1,9 @@
 ﻿namespace CompanyName.MyMeetings.Modules.UserAccess.Application.Contracts
 {
-    internal class CustomClaimTypes
+    public class CustomClaimTypes
     {
-        internal const string Roles = "roles";
-        internal const string Email = "email";
-        internal const string Name = "name";
+        public const string Roles = "roles";
+        public const string Email = "email";
+        public const string Name = "name";
     }
 }

--- a/src/Modules/UserAccess/Infrastructure/CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.csproj
+++ b/src/Modules/UserAccess/Infrastructure/CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.csproj
@@ -1,1 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="IdentityServer4" Version="4.1.2" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+  </ItemGroup>
+</Project>

--- a/src/Modules/UserAccess/Infrastructure/Configuration/Identity/IdentityConfiguration.cs
+++ b/src/Modules/UserAccess/Infrastructure/Configuration/Identity/IdentityConfiguration.cs
@@ -1,0 +1,40 @@
+using CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.IdentityServer;
+using IdentityServer4.AccessTokenValidation;
+using IdentityServer4.Validation;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.Configuration.Identity;
+
+public static class IdentityConfiguration
+{
+    public static IServiceCollection ConfigureIdentityService(this IServiceCollection services)
+    {
+        services.AddIdentityServer()
+            .AddInMemoryIdentityResources(IdentityServerConfig.GetIdentityResources())
+            .AddInMemoryApiScopes(IdentityServerConfig.GetApiScopes())
+            .AddInMemoryApiResources(IdentityServerConfig.GetApis())
+            .AddInMemoryClients(IdentityServerConfig.GetClients())
+            .AddInMemoryPersistedGrants()
+            .AddProfileService<ProfileService>()
+            .AddDeveloperSigningCredential();
+
+        services.AddTransient<IResourceOwnerPasswordValidator, ResourceOwnerPasswordValidator>();
+
+        services.AddAuthentication(IdentityServerAuthenticationDefaults.AuthenticationScheme)
+            .AddIdentityServerAuthentication(IdentityServerAuthenticationDefaults.AuthenticationScheme, x =>
+            {
+                x.Authority = "http://localhost:5000";
+                x.ApiName = "myMeetingsAPI";
+                x.RequireHttpsMetadata = false;
+            });
+
+        return services;
+    }
+
+    public static IApplicationBuilder AddIdentityService(this IApplicationBuilder app)
+    {
+        app.UseIdentityServer();
+        return app;
+    }
+}

--- a/src/Modules/UserAccess/Infrastructure/IdentityServer/IdentityServerConfig.cs
+++ b/src/Modules/UserAccess/Infrastructure/IdentityServer/IdentityServerConfig.cs
@@ -2,9 +2,9 @@
 using IdentityServer4;
 using IdentityServer4.Models;
 
-namespace CompanyName.MyMeetings.Modules.UserAccess.Application.IdentityServer
+namespace CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.IdentityServer
 {
-    public class IdentityServerConfig
+    internal class IdentityServerConfig
     {
         public static IEnumerable<ApiScope> GetApiScopes()
         {

--- a/src/Modules/UserAccess/Infrastructure/IdentityServer/ProfileService.cs
+++ b/src/Modules/UserAccess/Infrastructure/IdentityServer/ProfileService.cs
@@ -2,9 +2,9 @@
 using IdentityServer4.Models;
 using IdentityServer4.Services;
 
-namespace CompanyName.MyMeetings.Modules.UserAccess.Application.IdentityServer
+namespace CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.IdentityServer
 {
-    public class ProfileService : IProfileService
+    internal class ProfileService : IProfileService
     {
         public Task GetProfileDataAsync(ProfileDataRequestContext context)
         {

--- a/src/Modules/UserAccess/Infrastructure/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Modules/UserAccess/Infrastructure/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -3,9 +3,9 @@ using CompanyName.MyMeetings.Modules.UserAccess.Application.Contracts;
 using IdentityServer4.Models;
 using IdentityServer4.Validation;
 
-namespace CompanyName.MyMeetings.API.Modules.UserAccess
+namespace CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.IdentityServer
 {
-    public class ResourceOwnerPasswordValidator : IResourceOwnerPasswordValidator
+    internal class ResourceOwnerPasswordValidator : IResourceOwnerPasswordValidator
     {
         private readonly IUserAccessModule _userAccessModule;
 


### PR DESCRIPTION
This pull request moves the IdentityServer configuration and related classes from the UserAccess.Application.IdentityServer namespace to the UserAccess.Infrastructure.Configuration.Identity namespace. This improves the organization and separation of concerns within the UserModule.