### PR TITLE
Fix docker build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   mymeetingsdb:
     build: ./src/Database/
+    platform: linux/amd64
     ports:
       - 1445:1433
     networks:
@@ -26,8 +27,8 @@ services:
   migrator:
     container_name: mymeetings_db_migrator
     build:
-      context: ./src/Database/
-      dockerfile: Dockerfile_DatabaseMigrator
+      context: ./src/
+      dockerfile: ./Database/Dockerfile_DatabaseMigrator
     networks:
       - starfish-crm-network
     environment:

--- a/src/Database/Dockerfile_DatabaseMigrator
+++ b/src/Database/Dockerfile_DatabaseMigrator
@@ -4,12 +4,16 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
-COPY ["DatabaseMigrator/DatabaseMigrator.csproj", "DatabaseMigrator.csproj"]
-COPY ["DatabaseMigrator/DatabaseMigrator.csproj", "DatabaseMigrator.csproj"]
+COPY ["./Database/DatabaseMigrator/DatabaseMigrator.csproj", "DatabaseMigrator.csproj"]
+COPY ["Directory.Packages.props", "Directory.Packages.props"]
+COPY ["Directory.Build.targets", "Directory.Build.targets"]
+COPY ["Directory.Build.props", "Directory.Build.props"]
+COPY ["stylecop.json", "stylecop.json"]
+COPY [".editorconfig", ".editorconfig"]
 
 RUN dotnet restore "DatabaseMigrator.csproj"
 
-COPY . .
+COPY ./Database/ .
 
 WORKDIR "/src"
 RUN dotnet build "DatabaseMigrator.csproj" -c Release -o /app/build
@@ -21,11 +25,11 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 
-ADD entrypoint_DatabaseMigrator.sh /
-ADD CompanyName.MyMeetings.Database/Scripts/Migrations /migrations/
+ADD ./Database/entrypoint_DatabaseMigrator.sh /
+ADD ./Database/CompanyName.MyMeetings.Database/Scripts/Migrations /migrations/
 
 # Copy wait-for-it.sh into our image
-COPY wait-for-it.sh wait-for-it.sh
+COPY ./Database/wait-for-it.sh wait-for-it.sh
 # Make it executable, in Linux
 RUN chmod +x wait-for-it.sh
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,9 +4,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('API'))">
-    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" PrivateAssets="All" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" PrivateAssets="All" />
+    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Migrator'))">
     <PackageReference Include="dbup-sqlserver" Version="5.0.37" />

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -14,7 +14,6 @@ COPY ["BuildingBlocks/Infrastructure/CompanyName.MyMeetings.BuildingBlocks.Infra
 COPY ["BuildingBlocks/Domain/CompanyName.MyMeetings.BuildingBlocks.Domain.csproj", "BuildingBlocks/Domain/"]
 COPY ["BuildingBlocks/Application/CompanyName.MyMeetings.BuildingBlocks.Application.csproj", "BuildingBlocks/Application/"]
 COPY ["Modules/UserAccess/Domain/CompanyName.MyMeetings.Modules.UserAccess.Domain.csproj", "Modules/UserAccess/Domain/"]
-COPY ["BuildingBlocks/EventBus/CompanyName.MyMeetings.BuildingBlocks.EventBus.csproj", "BuildingBlocks/EventBus/"]
 COPY ["Modules/Meetings/IntegrationEvents/CompanyName.MyMeetings.Modules.Meetings.IntegrationEvents.csproj", "Modules/Meetings/IntegrationEvents/"]
 COPY ["Modules/Meetings/Application/CompanyName.MyMeetings.Modules.Meetings.Application.csproj", "Modules/Meetings/Application/"]
 COPY ["Modules/Meetings/Domain/CompanyName.MyMeetings.Modules.Meetings.Domain.csproj", "Modules/Meetings/Domain/"]
@@ -28,6 +27,9 @@ COPY ["Modules/Payments/Infrastructure/CompanyName.MyMeetings.Modules.Payments.I
 COPY ["Modules/Administration/Application/CompanyName.MyMeetings.Modules.Administration.Application.csproj", "Modules/Administration/Application/"]
 COPY ["Modules/Administration/Domain/CompanyName.MyMeetings.Modules.Administration.Domain.csproj", "Modules/Administration/Domain/"]
 COPY ["Modules/Administration/Infrastructure/CompanyName.MyMeetings.Modules.Administration.Infrastructure.csproj", "Modules/Administration/Infrastructure/"]
+COPY ["Directory.Packages.props", "Directory.Packages.props"]
+COPY ["Directory.Build.props", "Directory.Build.props"]
+COPY ["Directory.Build.targets", "Directory.Build.targets"]
 RUN dotnet restore "API/CompanyName.MyMeetings.API/CompanyName.MyMeetings.API.csproj"
 COPY . .
 WORKDIR "/src/API/CompanyName.MyMeetings.API"


### PR DESCRIPTION
### Summary
This pull request addresses a critical issue where the backend Docker image was failing to build correctly. The root cause was traced back to the recent update involving `directory.build.props` and related files, which were not being included in the Docker image(s).

### Details
- **directory.build.props** Missing directory.build.props and related files in build process of docker images
- **Removed old project** BuildingBlocks/EventBus/CompanyName.MyMeetings.BuildingBlocks.EventBus.csproj was still referenced in the build project which was removed during the upgrade to .net 8
- **Issue with Package References:** In the API project, the package references included the `PrivateAsset="All"` flag. This was preventing `dotnet pack` from copying necessary files, leading to the build issue.
- **DB Migrator Context Adjustment:** The Docker build context for the DB Migrator was set to `./src/database`. This limited its access to files located at the root of `./src` during the Docker build. I've adjusted the context to resolve this issue.
- **Compatibility with ARM-based MacBooks:** Added `platform: linux/amd64` to the `mymeetingsdb` container. This change ensures compatibility with ARM-based MacBooks (M1/M2), aiding in broader development support.

### Suggested Documentation Update
Given the compatibility enhancement for ARM processors, I recommend we include a link in the README to guide users on configuring Docker to run SQL Server on ARM architectures. This will be particularly helpful for those using newer MacBook models.



### Conclusion
These changes should resolve the backend en dbmigrator Docker image build issues and improve our project's compatibility across different development environments. I welcome any further suggestions.
In order to prevent breaking the docker images I created this issue #298
