### PR TITLE
Add missing tables for registrations

### DIFF
--- a/src/Database/CompanyName.MyMeetings.Database/CompanyName.MyMeetings.Database.sqlproj
+++ b/src/Database/CompanyName.MyMeetings.Database/CompanyName.MyMeetings.Database.sqlproj
@@ -178,6 +178,7 @@
     <None Include="Scripts\Migrations\1_0_0_0\0011_add_likes_count_to_meeting_comments_table.sql" />
     <None Include="Scripts\Migrations\1_0_0_0\0012_add_likes_count_to_meeting_comments_view.sql" />
     <None Include="Scripts\Migrations\1_0_0_0\0013_add_meeting_member_comment_likes_table.sql" />
+    <None Include="Scripts\Migrations\1_0_0_0\0014_add_missing_tables_for_registrations.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\ClearDatabase.sql" />

--- a/src/Database/CompanyName.MyMeetings.Database/CompanyName.MyMeetings.Database.sqlproj
+++ b/src/Database/CompanyName.MyMeetings.Database/CompanyName.MyMeetings.Database.sqlproj
@@ -91,6 +91,7 @@
     <Folder Include="Structure\registrations\" />
     <Folder Include="Structure\registrations\Tables\" />
     <Folder Include="Structure\registrations\Views\" />
+    <Folder Include="Structure\" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="Structure\administration\Tables\InboxMessages.sql" />
@@ -142,6 +143,9 @@
     <Build Include="Structure\payments\Tables\SubscriptionPayments.sql" />
     <Build Include="Structure\payments\Types\NewStreamMessages.sql" />
     <Build Include="Structure\registrations\Tables\UserRegistrations.sql" />
+    <Build Include="Structure\registrations\Tables\OutboxMessages.sql" />
+    <Build Include="Structure\registrations\Tables\InboxMessages.sql" />
+    <Build Include="Structure\registrations\Tables\InternalCommands.sql" />
     <Build Include="Structure\registrations\Views\v_UserRegistrations.sql" />
     <Build Include="Structure\Security\Schemas.sql" />
     <Build Include="Structure\users\Tables\InboxMessages.sql" />

--- a/src/Database/CompanyName.MyMeetings.Database/Scripts/Migrations/1_0_0_0/0014_add_missing_tables_for_registrations.sql
+++ b/src/Database/CompanyName.MyMeetings.Database/Scripts/Migrations/1_0_0_0/0014_add_missing_tables_for_registrations.sql
@@ -1,0 +1,33 @@
+﻿CREATE TABLE [registrations].[OutboxMessages]
+(
+	[Id] UNIQUEIDENTIFIER NOT NULL,
+	[OccurredOn] DATETIME2 NOT NULL,
+	[Type] VARCHAR(255) NOT NULL,
+	[Data] VARCHAR(MAX) NOT NULL,
+	[ProcessedDate] DATETIME2 NULL,
+	CONSTRAINT [PK_registrations_OutboxMessages_Id] PRIMARY KEY ([Id] ASC)
+)
+GO
+
+CREATE TABLE [registrations].[InternalCommands]
+(
+	[Id] UNIQUEIDENTIFIER NOT NULL,
+	[EnqueueDate] DATETIME2 NOT NULL,
+	[Type] VARCHAR(255) NOT NULL,
+	[Data] VARCHAR(MAX) NOT NULL,
+	[ProcessedDate] DATETIME2 NULL,
+	[Error] NVARCHAR(MAX) NULL,
+	CONSTRAINT [PK_registrations_InternalCommands_Id] PRIMARY KEY ([Id] ASC)
+)
+GO
+
+CREATE TABLE [registrations].[InboxMessages]
+(
+	[Id] UNIQUEIDENTIFIER NOT NULL,
+	[OccurredOn] DATETIME2 NOT NULL,
+	[Type] VARCHAR(255) NOT NULL,
+	[Data] VARCHAR(MAX) NOT NULL,
+	[ProcessedDate] DATETIME2 NULL,
+	CONSTRAINT [PK_registrations_InboxMessages_Id] PRIMARY KEY ([Id] ASC)
+)
+GO

--- a/src/Database/CompanyName.MyMeetings.Database/Structure/registrations/Tables/InboxMessages.sql
+++ b/src/Database/CompanyName.MyMeetings.Database/Structure/registrations/Tables/InboxMessages.sql
@@ -1,0 +1,10 @@
+﻿CREATE TABLE [registrations].InboxMessages
+(
+	[Id] UNIQUEIDENTIFIER NOT NULL,
+	[OccurredOn] DATETIME2 NOT NULL,
+	[Type] VARCHAR(255) NOT NULL,
+	[Data] VARCHAR(MAX) NOT NULL,
+	[ProcessedDate] DATETIME2 NULL,
+	CONSTRAINT [PK_registrations_InboxMessages_Id] PRIMARY KEY ([Id] ASC)
+)
+GO

--- a/src/Database/CompanyName.MyMeetings.Database/Structure/registrations/Tables/InternalCommands.sql
+++ b/src/Database/CompanyName.MyMeetings.Database/Structure/registrations/Tables/InternalCommands.sql
@@ -1,0 +1,11 @@
+﻿CREATE TABLE [registrations].InternalCommands
+(
+	[Id] UNIQUEIDENTIFIER NOT NULL,
+	[EnqueueDate] DATETIME2 NOT NULL,
+	[Type] VARCHAR(255) NOT NULL,
+	[Data] VARCHAR(MAX) NOT NULL,
+	[ProcessedDate] DATETIME2 NULL,
+	[Error] NVARCHAR(MAX) NULL,
+	CONSTRAINT [PK_registrations_InternalCommands_Id] PRIMARY KEY ([Id] ASC)
+)
+GO

--- a/src/Database/CompanyName.MyMeetings.Database/Structure/registrations/Tables/OutboxMessages.sql
+++ b/src/Database/CompanyName.MyMeetings.Database/Structure/registrations/Tables/OutboxMessages.sql
@@ -1,0 +1,10 @@
+﻿CREATE TABLE [registrations].OutboxMessages
+(
+	[Id] UNIQUEIDENTIFIER NOT NULL,
+	[OccurredOn] DATETIME2 NOT NULL,
+	[Type] VARCHAR(255) NOT NULL,
+	[Data] VARCHAR(MAX) NOT NULL,
+	[ProcessedDate] DATETIME2 NULL,
+	CONSTRAINT [PK_registrations_OutboxMessages_Id] PRIMARY KEY ([Id] ASC)
+)
+GO


### PR DESCRIPTION
I'm getting these errors when running the project:

`Invalid object name 'registrations.OutboxMessages'.`

`Invalid object name 'registrations.InternalCommands'.`

`Invalid object name 'registrations.InboxMessages'.`

I fixed them by executing the SQL scripts contained in this PR. These scripts were copied from similar scripts in the project, and modified for `registrations`.