### PR TITLE
Fix connection string for Registrations

### DIFF
--- a/src/API/CompanyName.MyMeetings.API/Startup.cs
+++ b/src/API/CompanyName.MyMeetings.API/Startup.cs
@@ -45,7 +45,7 @@ namespace CompanyName.MyMeetings.API
                 .AddEnvironmentVariables("Meetings_")
                 .Build();
 
-            _loggerForApi.Information("Connection string:" + _configuration.GetConnectionString("MeetingsConnectionString"));
+            _loggerForApi.Information("Connection string:" + _configuration.GetConnectionString(MeetingsConnectionString));
 
             AuthorizationChecker.CheckAllEndpoints();
         }
@@ -146,20 +146,20 @@ namespace CompanyName.MyMeetings.API
             var emailsConfiguration = new EmailsConfiguration(_configuration["EmailsConfiguration:FromEmail"]);
 
             MeetingsStartup.Initialize(
-                _configuration.GetConnectionString("MeetingsConnectionString"),
+                _configuration.GetConnectionString(MeetingsConnectionString),
                 executionContextAccessor,
                 _logger,
                 emailsConfiguration,
                 null);
 
             AdministrationStartup.Initialize(
-                _configuration.GetConnectionString("MeetingsConnectionString"),
+                _configuration.GetConnectionString(MeetingsConnectionString),
                 executionContextAccessor,
                 _logger,
                 null);
 
             UserAccessStartup.Initialize(
-                _configuration.GetConnectionString("MeetingsConnectionString"),
+                _configuration.GetConnectionString(MeetingsConnectionString),
                 executionContextAccessor,
                 _logger,
                 emailsConfiguration,
@@ -168,7 +168,7 @@ namespace CompanyName.MyMeetings.API
                 null);
 
             PaymentsStartup.Initialize(
-                _configuration.GetConnectionString("MeetingsConnectionString"),
+                _configuration.GetConnectionString(MeetingsConnectionString),
                 executionContextAccessor,
                 _logger,
                 emailsConfiguration,

--- a/src/API/CompanyName.MyMeetings.API/Startup.cs
+++ b/src/API/CompanyName.MyMeetings.API/Startup.cs
@@ -175,7 +175,7 @@ namespace CompanyName.MyMeetings.API
                 null);
 
             RegistrationsStartup.Initialize(
-                _configuration[MeetingsConnectionString],
+                _configuration.GetConnectionString(MeetingsConnectionString),
                 executionContextAccessor,
                 _logger,
                 emailsConfiguration,


### PR DESCRIPTION
Fix for error 

```
[... ERR] [Registrations] [] Job DEFAULT.9021bdbd-2... threw an unhandled Exception
System.InvalidOperationException: The ConnectionString property has not been initialized.
```

